### PR TITLE
Add Spring Boot credit card upgrade example using OAuth2 and WireMock

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,52 @@
-# boot-zosproxy-mainframe-oauth2-wiremock
-real time card upgrade example. integrating mainframe to web using spring boot and oauth thriugh z/os( gateway API for ibmmainframe). test using wiremock. and test using mock oauth2 tokens
+# Credit Card Upgrade Sample
+
+This project demonstrates a Spring Boot web application that upgrades a customer's credit card by calling mainframe services exposed through IBM z/OS Connect.  The application communicates with the mainframe using REST and secures the interaction with OAuth2 bearer tokens.
+
+## Features
+
+* REST endpoint `/api/cards/upgrade` that receives upgrade requests.
+* `WebClient` configured with OAuth2 **client credentials** retrieves a JWT and calls the z/OS Connect API.
+* Spring Security OAuth2 resource server protects the endpoint with JWT bearer tokens.
+* WireMock based tests simulate the mainframe API and an OAuth token service so the application can be tested locally on Windows with no mainframe.
+
+## Project layout
+```
+src/main/java/com/example/creditcard
+├── CreditCardUpgradeApplication.java
+├── config
+│   ├── SecurityConfig.java
+│   └── WebClientConfig.java
+├── controller
+│   └── CreditCardUpgradeController.java
+├── model
+│   ├── CreditCardUpgradeRequest.java
+│   └── CreditCardUpgradeResponse.java
+└── service
+    └── CreditCardUpgradeService.java
+```
+
+## Running tests
+
+1. Ensure JDK 17 and Maven are installed.
+2. Execute `mvn test`.
+   WireMock spins up a mock mainframe and OAuth server, generating tokens and responses for the upgrade request.
+
+The tests verify that the application obtains a token, sends it to the mocked z/OS Connect endpoint and returns the upgrade response.
+
+## Calling the service
+
+Run the application with `mvn spring-boot:run` and issue a request:
+
+```
+POST http://localhost:8080/api/cards/upgrade
+Authorization: Bearer <jwt>
+Content-Type: application/json
+
+{
+  "accountNumber": "123456",
+  "currentCardType": "SILVER",
+  "desiredCardType": "GOLD"
+}
+```
+
+The app forwards the request to z/OS Connect using a new OAuth2 token and returns the mainframe response.

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,65 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>com.example</groupId>
+    <artifactId>credit-card-upgrade</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <packaging>jar</packaging>
+    <name>Credit Card Upgrade</name>
+    <description>Spring Boot app integrating with z/OS Connect and OAuth2</description>
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>3.2.3</version>
+        <relativePath/> <!-- lookup parent from repository -->
+    </parent>
+    <properties>
+        <java.version>17</java.version>
+    </properties>
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-security</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-oauth2-client</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-oauth2-resource-server</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.github.tomakehurst</groupId>
+            <artifactId>wiremock-jre8</artifactId>
+            <version>2.35.1</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/main/java/com/example/creditcard/CreditCardUpgradeApplication.java
+++ b/src/main/java/com/example/creditcard/CreditCardUpgradeApplication.java
@@ -1,0 +1,12 @@
+package com.example.creditcard;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class CreditCardUpgradeApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(CreditCardUpgradeApplication.class, args);
+    }
+}

--- a/src/main/java/com/example/creditcard/config/SecurityConfig.java
+++ b/src/main/java/com/example/creditcard/config/SecurityConfig.java
@@ -1,0 +1,20 @@
+package com.example.creditcard.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers("/api/**").authenticated()
+                        .anyRequest().permitAll())
+                .oauth2ResourceServer(oauth2 -> oauth2.jwt());
+        return http.build();
+    }
+}

--- a/src/main/java/com/example/creditcard/config/WebClientConfig.java
+++ b/src/main/java/com/example/creditcard/config/WebClientConfig.java
@@ -1,0 +1,42 @@
+package com.example.creditcard.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.oauth2.client.AuthorizedClientServiceOAuth2AuthorizedClientManager;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClientManager;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClientProvider;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClientProviderBuilder;
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClientService;
+import org.springframework.security.oauth2.client.web.reactive.function.client.ServletOAuth2AuthorizedClientExchangeFilterFunction;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Configuration
+public class WebClientConfig {
+
+    @Bean
+    public OAuth2AuthorizedClientManager authorizedClientManager(
+            ClientRegistrationRepository clientRegistrationRepository,
+            OAuth2AuthorizedClientService authorizedClientService) {
+        OAuth2AuthorizedClientProvider authorizedClientProvider =
+                OAuth2AuthorizedClientProviderBuilder.builder()
+                        .clientCredentials()
+                        .build();
+
+        AuthorizedClientServiceOAuth2AuthorizedClientManager authorizedClientManager =
+                new AuthorizedClientServiceOAuth2AuthorizedClientManager(
+                        clientRegistrationRepository, authorizedClientService);
+        authorizedClientManager.setAuthorizedClientProvider(authorizedClientProvider);
+        return authorizedClientManager;
+    }
+
+    @Bean
+    public WebClient webClient(OAuth2AuthorizedClientManager authorizedClientManager) {
+        ServletOAuth2AuthorizedClientExchangeFilterFunction oauth2 =
+                new ServletOAuth2AuthorizedClientExchangeFilterFunction(authorizedClientManager);
+        oauth2.setDefaultClientRegistrationId("zos");
+        return WebClient.builder()
+                .apply(oauth2.oauth2Configuration())
+                .build();
+    }
+}

--- a/src/main/java/com/example/creditcard/controller/CreditCardUpgradeController.java
+++ b/src/main/java/com/example/creditcard/controller/CreditCardUpgradeController.java
@@ -1,0 +1,26 @@
+package com.example.creditcard.controller;
+
+import com.example.creditcard.model.CreditCardUpgradeRequest;
+import com.example.creditcard.model.CreditCardUpgradeResponse;
+import com.example.creditcard.service.CreditCardUpgradeService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/cards")
+public class CreditCardUpgradeController {
+
+    private final CreditCardUpgradeService service;
+
+    public CreditCardUpgradeController(CreditCardUpgradeService service) {
+        this.service = service;
+    }
+
+    @PostMapping("/upgrade")
+    public ResponseEntity<CreditCardUpgradeResponse> upgrade(@RequestBody CreditCardUpgradeRequest request) {
+        return ResponseEntity.ok(service.upgradeCard(request));
+    }
+}

--- a/src/main/java/com/example/creditcard/model/CreditCardUpgradeRequest.java
+++ b/src/main/java/com/example/creditcard/model/CreditCardUpgradeRequest.java
@@ -1,0 +1,31 @@
+package com.example.creditcard.model;
+
+public class CreditCardUpgradeRequest {
+    private String accountNumber;
+    private String currentCardType;
+    private String desiredCardType;
+
+    public String getAccountNumber() {
+        return accountNumber;
+    }
+
+    public void setAccountNumber(String accountNumber) {
+        this.accountNumber = accountNumber;
+    }
+
+    public String getCurrentCardType() {
+        return currentCardType;
+    }
+
+    public void setCurrentCardType(String currentCardType) {
+        this.currentCardType = currentCardType;
+    }
+
+    public String getDesiredCardType() {
+        return desiredCardType;
+    }
+
+    public void setDesiredCardType(String desiredCardType) {
+        this.desiredCardType = desiredCardType;
+    }
+}

--- a/src/main/java/com/example/creditcard/model/CreditCardUpgradeResponse.java
+++ b/src/main/java/com/example/creditcard/model/CreditCardUpgradeResponse.java
@@ -1,0 +1,31 @@
+package com.example.creditcard.model;
+
+public class CreditCardUpgradeResponse {
+    private String status;
+    private String message;
+    private String upgradeId;
+
+    public String getStatus() {
+        return status;
+    }
+
+    public void setStatus(String status) {
+        this.status = status;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public void setMessage(String message) {
+        this.message = message;
+    }
+
+    public String getUpgradeId() {
+        return upgradeId;
+    }
+
+    public void setUpgradeId(String upgradeId) {
+        this.upgradeId = upgradeId;
+    }
+}

--- a/src/main/java/com/example/creditcard/service/CreditCardUpgradeService.java
+++ b/src/main/java/com/example/creditcard/service/CreditCardUpgradeService.java
@@ -1,0 +1,31 @@
+package com.example.creditcard.service;
+
+import com.example.creditcard.model.CreditCardUpgradeRequest;
+import com.example.creditcard.model.CreditCardUpgradeResponse;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Service
+public class CreditCardUpgradeService {
+
+    private final WebClient webClient;
+    private final String zosBaseUrl;
+
+    public CreditCardUpgradeService(WebClient webClient,
+                                    @Value("${zos.api.baseUrl}") String zosBaseUrl) {
+        this.webClient = webClient;
+        this.zosBaseUrl = zosBaseUrl;
+    }
+
+    public CreditCardUpgradeResponse upgradeCard(CreditCardUpgradeRequest request) {
+        return webClient.post()
+                .uri(zosBaseUrl + "/card/upgrade")
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue(request)
+                .retrieve()
+                .bodyToMono(CreditCardUpgradeResponse.class)
+                .block();
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,23 @@
+server:
+  port: 8080
+
+zos:
+  api:
+    baseUrl: ${ZOS_API_BASEURL:http://localhost:8089/zos}
+
+spring:
+  security:
+    oauth2:
+      client:
+        registration:
+          zos:
+            client-id: demo-client
+            client-secret: demo-secret
+            authorization-grant-type: client_credentials
+            scope: zos.read
+        provider:
+          zos:
+            token-uri: ${OAUTH_TOKEN_URI:http://localhost:8089/oauth/token}
+      resourceserver:
+        jwt:
+          jwk-set-uri: ${OAUTH_JWKS_URI:http://localhost:8089/oauth/jwks}

--- a/src/test/java/com/example/creditcard/CreditCardUpgradeIntegrationTest.java
+++ b/src/test/java/com/example/creditcard/CreditCardUpgradeIntegrationTest.java
@@ -1,0 +1,81 @@
+package com.example.creditcard;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ExtendWith(SpringExtension.class)
+public class CreditCardUpgradeIntegrationTest {
+
+    private static final WireMockServer wireMockServer = new WireMockServer(options().dynamicPort());
+
+    static {
+        wireMockServer.start();
+    }
+
+    @DynamicPropertySource
+    static void registerProperties(DynamicPropertyRegistry registry) {
+        String baseUrl = "http://localhost:" + wireMockServer.port();
+        registry.add("ZOS_API_BASEURL", () -> baseUrl + "/zos");
+        registry.add("OAUTH_TOKEN_URI", () -> baseUrl + "/oauth/token");
+        registry.add("OAUTH_JWKS_URI", () -> baseUrl + "/oauth/jwks");
+    }
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    void setup() {
+        wireMockServer.resetAll();
+        wireMockServer.stubFor(post(urlEqualTo("/oauth/token"))
+                .willReturn(aResponse()
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("{\"access_token\":\"mainframe-token\",\"token_type\":\"Bearer\",\"expires_in\":3600}")));
+
+        wireMockServer.stubFor(post(urlEqualTo("/zos/card/upgrade"))
+                .withHeader("Authorization", equalTo("Bearer mainframe-token"))
+                .willReturn(aResponse()
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("{\"status\":\"SUCCESS\",\"message\":\"Upgrade accepted\",\"upgradeId\":\"42\"}")));
+
+        wireMockServer.stubFor(get(urlEqualTo("/oauth/jwks"))
+                .willReturn(okJson("{\"keys\":[]}")));
+    }
+
+    @AfterAll
+    static void tearDown() {
+        wireMockServer.stop();
+    }
+
+    @Test
+    void upgradeCard() throws Exception {
+        String requestBody = "{\"accountNumber\":\"123456\",\"currentCardType\":\"SILVER\",\"desiredCardType\":\"GOLD\"}";
+
+        mockMvc.perform(post("/api/cards/upgrade")
+                        .with(jwt())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestBody))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("SUCCESS"))
+                .andExpect(jsonPath("$.upgradeId").value("42"));
+    }
+}


### PR DESCRIPTION
## Summary
- implement credit card upgrade service and REST controller
- secure APIs with OAuth2 JWT resource server
- configure WebClient OAuth2 client and add WireMock integration test

## Testing
- `mvn -q test` *(failed: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent due to network being unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689a19e0f6448321afa3f55154a9a77c